### PR TITLE
Just need to check the last byte.

### DIFF
--- a/id/src/commonMain/kotlin/diglol/id/Id.kt
+++ b/id/src/commonMain/kotlin/diglol/id/Id.kt
@@ -140,6 +140,9 @@ class Id private constructor(private val raw: ByteArray) : Comparable<Id> {
       }
       val raw = ByteArray(rawSize)
       raw[12] = ((decode[srcInts[19]] shl 4) or (decode[srcInts[20]] shr 1)).toByte()
+      if (encode[(raw[12].toInt() and 0xff shl 1) and 0x1f] != src[20]) {
+        return empty
+      }
       raw[11] =
         ((decode[srcInts[17]] shl 6) or (decode[srcInts[18]] shl 1) or (decode[srcInts[19]] shr 4)).toByte()
       raw[10] = ((decode[srcInts[16]] shl 3) or (decode[srcInts[17]] shr 2)).toByte()
@@ -157,16 +160,7 @@ class Id private constructor(private val raw: ByteArray) : Comparable<Id> {
       raw[1] =
         ((decode[srcInts[1]] shl 6) or (decode[srcInts[2]] shl 1) or (decode[srcInts[3]] shr 4)).toByte()
       raw[0] = ((decode[srcInts[0]] shl 3) or (decode[srcInts[1]] shr 2)).toByte()
-
-      // check
-      val checkRawInts = raw.copyOfRange(10, 13).map { v -> v.toInt() and 0xff } // big endian
-      val check = byteArrayOf(
-        encode[(checkRawInts[1] shr 6) and 0x1f or (checkRawInts[0] shl 2) and 0x1f],
-        encode[(checkRawInts[1] shr 1) and 0x1f],
-        encode[(checkRawInts[2] shr 4) and 0x1f or (checkRawInts[1] shl 4) and 0x1f],
-        encode[(checkRawInts[2] shl 1) and 0x1f]
-      )
-      return if (check.contentEquals(src.copyOfRange(17, 21))) Id(raw) else empty
+      return Id(raw)
     }
 
     private fun generateRaw(epochSeconds: Long): ByteArray {

--- a/id/src/commonTest/kotlin/diglol/id/IdTest.kt
+++ b/id/src/commonTest/kotlin/diglol/id/IdTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class IdTest {
@@ -38,6 +39,13 @@ class IdTest {
     val epochSeconds = epochSeconds()
     val id = Id.generate(epochSeconds)
     assertEquals(epochSeconds, id.time)
+  }
+
+  @Test
+  fun padding() {
+    val id1 = "016ohoarc3q8dp1884ms1".decodeToId() // invalid
+    val id2 = "016ohoarc3q8dp1884ms0".decodeToId()
+    assertNotEquals(id1, id2)
   }
 
   @Test


### PR DESCRIPTION
old:
```
Warm-up 1: 0.181 us/op
Warm-up 2: 0.176 us/op
Warm-up 3: 0.182 us/op
Warm-up 4: 0.175 us/op
Warm-up 5: 0.176 us/op
Iteration 1: 0.180 us/op
Iteration 2: 0.179 us/op
Iteration 3: 0.204 us/op
Iteration 4: 0.184 us/op
Iteration 5: 0.203 us/op

  Success: 0.190 ±(99.9%) 0.049 us/op [Average]
  (min, avg, max) = (0.179, 0.190, 0.204), stdev = 0.013
  CI (99.9%): [0.141, 0.239] (assumes normal distribution)


jvm summary:
Benchmark                     Mode  Cnt  Score   Error  Units
IdBenchmark.stringDecodeToId  avgt    5  0.190 ± 0.049  us/op
```

new:
```
Warm-up 1: 0.144 us/op
Warm-up 2: 0.145 us/op
Warm-up 3: 0.143 us/op
Warm-up 4: 0.144 us/op
Warm-up 5: 0.143 us/op
Iteration 1: 0.146 us/op
Iteration 2: 0.144 us/op
Iteration 3: 0.143 us/op
Iteration 4: 0.141 us/op
Iteration 5: 0.143 us/op

  Success: 0.143 ±(99.9%) 0.006 us/op [Average]
  (min, avg, max) = (0.141, 0.143, 0.146), stdev = 0.002
  CI (99.9%): [0.137, 0.150] (assumes normal distribution)


jvm summary:
Benchmark                     Mode  Cnt  Score   Error  Units
IdBenchmark.stringDecodeToId  avgt    5  0.143 ± 0.006  us/op
```