### PR TITLE
Avoid type casting

### DIFF
--- a/id/src/commonMain/kotlin/diglol/id/Id.kt
+++ b/id/src/commonMain/kotlin/diglol/id/Id.kt
@@ -111,7 +111,9 @@ class Id private constructor(private val raw: ByteArray) : Comparable<Id> {
 
     private fun encode(raw: ByteArray): ByteArray {
       val dst = ByteArray(encodedSize)
-      val rawInts = raw.map { v -> v.toInt() and 0xff } // big endian
+      val rawInts = IntArray(rawSize) { index ->
+        raw[index].toInt() and 0xff // big endian
+      }
 
       dst[20] = encode[(rawInts[12] shl 1) and 0x1f]
       dst[19] = encode[(rawInts[12] shr 4) or (rawInts[11] shl 4) and 0x1f]
@@ -138,12 +140,12 @@ class Id private constructor(private val raw: ByteArray) : Comparable<Id> {
     }
 
     private fun decode(src: ByteArray): Id {
-      val srcInts = src.map { v ->
-        val vi = v.toInt()
-        if (decode[vi] == -1) {
+      val srcInts = IntArray(encodedSize) { index ->
+        val v = src[index].toInt()
+        if (decode[v] == -1) {
           return empty
         }
-        vi
+        v
       }
       val raw = ByteArray(rawSize)
       raw[12] = ((decode[srcInts[19]] shl 4) or (decode[srcInts[20]] shr 1)).toByte()


### PR DESCRIPTION
old:
```
jvm summary:
Benchmark                     Mode  Cnt  Score    Error  Units
IdBenchmark.generate          avgt    5  0.075 ±  0.001  us/op
IdBenchmark.generateToString  avgt    5  0.155 ±  0.008  us/op
IdBenchmark.stringDecodeToId  avgt    5  0.133 ±  0.364  us/op
```
```java
    private final byte[] encode(byte[] raw) {
      byte[] dst = new byte[21];
      byte[] $this$map$iv = raw;
      int $i$f$map = 0;
      byte[] arrayOfByte1 = $this$map$iv;
      Collection<Integer> destination$iv$iv = new ArrayList($this$map$iv.length);
      int $i$f$mapTo = 0;
      byte b;
      int i;
      for (b = 0, i = arrayOfByte1.length; b < i; ) {
        byte item$iv$iv = arrayOfByte1[b];
        byte b1 = item$iv$iv;
        Collection<Integer> collection = destination$iv$iv;
        int $i$a$-map-Id$Companion$encode$rawInts$1 = 0;
        collection.add(Integer.valueOf(b1 & 0xFF));
      } 
      List rawInts = (List)destination$iv$iv;
      dst[20] = Id.encode[((Number)rawInts.get(12)).intValue() << 1 & 0x1F];
      dst[19] = Id.encode[(((Number)rawInts.get(12)).intValue() >> 4 | ((Number)rawInts.get(11)).intValue() << 4) & 0x1F];
      dst[18] = Id.encode[((Number)rawInts.get(11)).intValue() >> 1 & 0x1F];
      dst[17] = Id.encode[(((Number)rawInts.get(11)).intValue() >> 6 | ((Number)rawInts.get(10)).intValue() << 2) & 0x1F];
      dst[16] = Id.encode[((Number)rawInts.get(10)).intValue() >> 3];
      dst[15] = Id.encode[((Number)rawInts.get(9)).intValue() & 0x1F];
      dst[14] = Id.encode[(((Number)rawInts.get(9)).intValue() >> 5 | ((Number)rawInts.get(8)).intValue() << 3) & 0x1F];
      dst[13] = Id.encode[((Number)rawInts.get(8)).intValue() >> 2 & 0x1F];
      dst[12] = Id.encode[(((Number)rawInts.get(8)).intValue() >> 7 | ((Number)rawInts.get(7)).intValue() << 1) & 0x1F];
      dst[11] = Id.encode[(((Number)rawInts.get(7)).intValue() >> 4 | ((Number)rawInts.get(6)).intValue() << 4) & 0x1F];
      dst[10] = Id.encode[((Number)rawInts.get(6)).intValue() >> 1 & 0x1F];
      dst[9] = Id.encode[(((Number)rawInts.get(6)).intValue() >> 6 | ((Number)rawInts.get(5)).intValue() << 2) & 0x1F];
      dst[8] = Id.encode[((Number)rawInts.get(5)).intValue() >> 3];
      dst[7] = Id.encode[((Number)rawInts.get(4)).intValue() & 0x1F];
      dst[6] = Id.encode[(((Number)rawInts.get(4)).intValue() >> 5 | ((Number)rawInts.get(3)).intValue() << 3) & 0x1F];
      dst[5] = Id.encode[((Number)rawInts.get(3)).intValue() >> 2 & 0x1F];
      dst[4] = Id.encode[(((Number)rawInts.get(3)).intValue() >> 7 | ((Number)rawInts.get(2)).intValue() << 1) & 0x1F];
      dst[3] = Id.encode[(((Number)rawInts.get(2)).intValue() >> 4 | ((Number)rawInts.get(1)).intValue() << 4) & 0x1F];
      dst[2] = Id.encode[((Number)rawInts.get(1)).intValue() >> 1 & 0x1F];
      dst[1] = Id.encode[(((Number)rawInts.get(1)).intValue() >> 6 | ((Number)rawInts.get(0)).intValue() << 2) & 0x1F];
      dst[0] = Id.encode[((Number)rawInts.get(0)).intValue() >> 3];
      return dst;
    }
```

new:
```
jvm summary:
Benchmark                     Mode  Cnt  Score   Error  Units
IdBenchmark.generate          avgt    5  0.073 ± 0.001  us/op
IdBenchmark.generateToString  avgt    5  0.109 ± 0.002  us/op
IdBenchmark.stringDecodeToId  avgt    5  0.088 ± 0.004  us/op
```
```java
    private final byte[] encode(byte[] raw) {
      byte[] dst = new byte[21];
      int[] arrayOfInt1;
      for (byte b = 0; b < 13; ) {
        byte b1 = b;
        arrayOfInt1[b1] = raw[b1] & 0xFF;
        b++;
      } 
      int[] rawInts = arrayOfInt1;
      dst[20] = Id.encode[rawInts[12] << 1 & 0x1F];
      dst[19] = Id.encode[(rawInts[12] >> 4 | rawInts[11] << 4) & 0x1F];
      dst[18] = Id.encode[rawInts[11] >> 1 & 0x1F];
      dst[17] = Id.encode[(rawInts[11] >> 6 | rawInts[10] << 2) & 0x1F];
      dst[16] = Id.encode[rawInts[10] >> 3];
      dst[15] = Id.encode[rawInts[9] & 0x1F];
      dst[14] = Id.encode[(rawInts[9] >> 5 | rawInts[8] << 3) & 0x1F];
      dst[13] = Id.encode[rawInts[8] >> 2 & 0x1F];
      dst[12] = Id.encode[(rawInts[8] >> 7 | rawInts[7] << 1) & 0x1F];
      dst[11] = Id.encode[(rawInts[7] >> 4 | rawInts[6] << 4) & 0x1F];
      dst[10] = Id.encode[rawInts[6] >> 1 & 0x1F];
      dst[9] = Id.encode[(rawInts[6] >> 6 | rawInts[5] << 2) & 0x1F];
      dst[8] = Id.encode[rawInts[5] >> 3];
      dst[7] = Id.encode[rawInts[4] & 0x1F];
      dst[6] = Id.encode[(rawInts[4] >> 5 | rawInts[3] << 3) & 0x1F];
      dst[5] = Id.encode[rawInts[3] >> 2 & 0x1F];
      dst[4] = Id.encode[(rawInts[3] >> 7 | rawInts[2] << 1) & 0x1F];
      dst[3] = Id.encode[(rawInts[2] >> 4 | rawInts[1] << 4) & 0x1F];
      dst[2] = Id.encode[rawInts[1] >> 1 & 0x1F];
      dst[1] = Id.encode[(rawInts[1] >> 6 | rawInts[0] << 2) & 0x1F];
      dst[0] = Id.encode[rawInts[0] >> 3];
      return dst;
    }
```